### PR TITLE
Add simple chatbot with backend endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
-# smart-shopping-system
-AI-supported customer profiling and data visualization project
+# Smart Shopping System
+
+This project contains a FastAPI backend and a React frontend for customer profiling and analytics.
+
+## Running the backend
+
+```bash
+pip install -r backend/requirements.txt
+uvicorn backend.app.main:app --reload
+```
+
+## Running the frontend
+
+```bash
+cd frontend/shoplens-frontend
+npm install
+npm run dev
+```
+
+## Chatbot
+
+Both the seller and customer dashboards now include a simple chatbot. Type a question such as `top categories` or `review score` to see data driven responses.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -47,6 +47,9 @@ class CustomerData(BaseModel):
     active_days: int
     repeat_purchase_ratio: float
 
+class ChatRequest(BaseModel):
+    message: str
+
 # ENDPOINTLER
 @app.get("/all-users")
 def get_all_users():
@@ -97,6 +100,18 @@ def get_customer(customer_id: str):
 def get_top_categories():
     top_counts = df["product_category"].value_counts().head(5)
     return top_counts.to_dict()
+
+@app.post("/chat")
+def chat(req: ChatRequest):
+    message = req.message.lower()
+    if "top categories" in message:
+        top_counts = df["product_category"].value_counts().head(3)
+        summary = ", ".join([f"{k} ({v})" for k, v in top_counts.to_dict().items()])
+        return {"reply": f"Top categories: {summary}"}
+    if "review score" in message:
+        avg = round(df["review_score"].mean(), 2)
+        return {"reply": f"Average review score is {avg}."}
+    return {"reply": "Sorry, I can answer about top categories or review score."}
 
 
 

--- a/frontend/shoplens-frontend/src/components/Chatbot.jsx
+++ b/frontend/shoplens-frontend/src/components/Chatbot.jsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import axios from 'axios';
+
+const Chatbot = () => {
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+
+  const sendMessage = async () => {
+    if (!input.trim()) return;
+    const userMsg = { from: 'user', text: input };
+    setMessages(msgs => [...msgs, userMsg]);
+    try {
+      const res = await axios.post('http://localhost:8000/chat', { message: input });
+      const botMsg = { from: 'bot', text: res.data.reply };
+      setMessages(msgs => [...msgs, botMsg]);
+    } catch (err) {
+      setMessages(msgs => [...msgs, { from: 'bot', text: 'Server error.' }]);
+    }
+    setInput('');
+  };
+
+  return (
+    <div className="bg-white shadow-md rounded p-4">
+      <div className="h-64 overflow-y-auto mb-4 space-y-2">
+        {messages.map((m, i) => (
+          <div key={i} className={m.from === 'user' ? 'text-right' : 'text-left'}>
+            <span className="inline-block px-3 py-1 rounded bg-gray-200">
+              {m.text}
+            </span>
+          </div>
+        ))}
+      </div>
+      <div className="flex">
+        <input
+          className="flex-1 border p-2 rounded-l"
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          onKeyDown={e => e.key === 'Enter' && sendMessage()}
+          placeholder="Ask something..."
+        />
+        <button onClick={sendMessage} className="bg-blue-500 text-white px-4 rounded-r">
+          Send
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default Chatbot;

--- a/frontend/shoplens-frontend/src/pages/CustomerDashboard.jsx
+++ b/frontend/shoplens-frontend/src/pages/CustomerDashboard.jsx
@@ -4,6 +4,7 @@ import Sidebar from "../components/Sidebar";
 import CustomerPersonaCard from "../components/CustomerPersonaCard";
 import OrderTrendsChart from "../components/OrderTrendsChart";
 import CategoryPieChart from "../components/CategoryPieChart";
+import Chatbot from "../components/Chatbot";
 
 
 
@@ -25,12 +26,12 @@ const CustomerDashboard = () => {
         <div className="flex-1 p-6 overflow-auto space-y-8">
           {/* Persona Kartı */}
           <CustomerPersonaCard email={email} />
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <OrderTrendsChart email={email} />
+            <CategoryPieChart email={email} />
+          </div>
+          <Chatbot />
         </div>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-  <OrderTrendsChart email={email} />
-  <CategoryPieChart email={email} />
-</div>
-
       </div>
     </div>
   );

--- a/frontend/shoplens-frontend/src/pages/SellerDashboard.jsx
+++ b/frontend/shoplens-frontend/src/pages/SellerDashboard.jsx
@@ -8,6 +8,7 @@ import StatCard from "../components/StatCard";
 import ReturnRateChart from "../components/ReturnRateChart";
 import { Repeat } from 'lucide-react';
 import StockStatus from "../components/StockStatus";
+import Chatbot from "../components/Chatbot";
 
 
 
@@ -186,6 +187,9 @@ const SellerDashboard = () => {
           <ReturnRateChart />
         </div>
       )}
+      <div className="mt-10 max-w-xl">
+        <Chatbot />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add `/chat` API to backend with basic keyword responses
- create `Chatbot.jsx` React component for chatting
- embed chatbot on seller and customer dashboards
- update README with running instructions

## Testing
- `npm test` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_684019f4bf78832a95c4ef00dccae222